### PR TITLE
fix strncmp by incrementing char pointers at end of comparison loop

### DIFF
--- a/src/libc/string.c
+++ b/src/libc/string.c
@@ -57,7 +57,7 @@ int strncmp(const char *s1, const char *s2, size_t n)
 {
     size_t i;
 
-    for (i = 0; i < n; ++i) {
+    for (i = 0; i < n; ++i, ++s1, ++s2) {
         if (*s1 == *s2) {
             continue;
         }


### PR DESCRIPTION
Bug in ./src/libc/string.c. strncmp() was not incrementing the comparison pointers, so the comparison loop was just comparing the first chars of the string n times.
